### PR TITLE
Add media redirection style

### DIFF
--- a/app/src/main/java/lantian/nolitter/views/screens/General.kt
+++ b/app/src/main/java/lantian/nolitter/views/screens/General.kt
@@ -35,7 +35,12 @@ fun General(viewModel: MainViewModel = hiltViewModel(LocalActivity.current)) {
             text = stringResource(R.string.ui_settings_redirectStyle),
             secondaryText = stringResource(R.string.ui_settings_redirectStyle_description),
             dialogTitle = stringResource(R.string.ui_settings_redirectStyle),
-            options = mapOf("data" to "Data", "cache" to "Cache", "external" to "External"),
+            options = mapOf(
+                "data" to "Data",
+                "cache" to "Cache",
+                "external" to "External",
+                "media" to "Media"
+            ),
             defaultValue = viewModel.getPreference("redirect_style", "data"),
             onSubmit = { viewModel.setPreference("redirect_style", it) }
         )

--- a/app/src/main/java/lantian/nolitter/xposed/XposedHook.kt
+++ b/app/src/main/java/lantian/nolitter/xposed/XposedHook.kt
@@ -190,6 +190,7 @@ class XposedHook : IXposedHookLoadPackage {
             "data" -> "/Android/data/${applicationContext.packageName}/sdcard"
             "cache" -> "/Android/data/${applicationContext.packageName}/cache/sdcard"
             "external" -> "/Android/files/${applicationContext.packageName}"
+            "media" -> "/Android/media/${applicationContext.packageName}/sdcard"
             else -> throw IllegalArgumentException("Invalid redirect style")
         }
     }


### PR DESCRIPTION
**Add media redirection style.** 

Because the number of apps in the `Android/media` file is smaller than the number of `Android/data` files, you can locate your redirected files more quickly, if necessary.

